### PR TITLE
Update Spring Boot 2.6.1&Kotlin1.6.0&Gradle7.3.1&eclipse-temurin11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-alpine-slim
+FROM eclipse-temurin:11
 EXPOSE 8080
 EXPOSE 9010
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Spring Boot Kotlin の Docker Build Sample
 
 # 前提
 -   JDK
-    - [OpenJDK (11.0.x)](http://openjdk.java.net/)
+    - [Eclipse Temurin (11.0.x)](https://adoptium.net/)
 -   Kotlin
-    - [Kotlin (1.5.31)](https://kotlinlang.org/)
+    - [Kotlin (1.6.0)](https://kotlinlang.org/)
 -   Build Tool
-    - [Gradle (7.2)](https://gradle.org/)
+    - [Gradle (7.3.1)](https://gradle.org/)
 -   Framework
-    - [Spring Boot (2.5.5.RELEASE)](https://spring.io/projects/spring-boot)
+    - [Spring Boot (2.6.1.RELEASE)](https://spring.io/projects/spring-boot)
     - [Spring REST Docs (2.0.5.RELEASE)](https://spring.io/projects/spring-restdocs)
 -   IDE
     - [Eclipse (2021‑03)](http://www.eclipse.org/home/index.php) + [Spring Tools](https://marketplace.eclipse.org/content/spring-tool-suite-sts-eclipse)
-    - [IntelliJ IDEA CE (2021.1)](https://www.jetbrains.com/ja-jp/idea/download/)
+    - [IntelliJ IDEA CE (2021.3)](https://www.jetbrains.com/ja-jp/idea/download/)
 
 
 # 利用方法

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  id("org.springframework.boot") version "2.5.5"
+  id("org.springframework.boot") version "2.6.1"
   id("io.spring.dependency-management") version "1.0.11.RELEASE"
-  kotlin("jvm") version "1.5.31"
-  kotlin("plugin.spring") version "1.5.31"
+  kotlin("jvm") version "1.6.0"
+  kotlin("plugin.spring") version "1.6.0"
   id("org.asciidoctor.jvm.convert") version "3.3.2"
-  id("org.jetbrains.dokka") version "1.5.31"
+  id("org.jetbrains.dokka") version "1.6.0"
   id("war")
   id("com.github.ben-manes.versions") version "0.39.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
[対応内容]
- Update Gradle Ver 7.3.1
- Update Spring Boot Ver 2.6.1
- Update Kotlin1.6.0
- Change Eclipse Temurin Ver 11